### PR TITLE
refactor: replace no_scrollbar and no_appearance classes with teppen-…

### DIFF
--- a/src/main.css
+++ b/src/main.css
@@ -1,18 +1,3 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-.no_scrollbar {
-  -ms-overflow-style: none; /* IE and Edge */
-  scrollbar-width: none; /* Firefox */
-}
-
-.no_scrollbar::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera*/
-}
-
-.no_appearance {
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  appearance: none;
-}

--- a/src/search-bar/condition-search-bar/base.tsx
+++ b/src/search-bar/condition-search-bar/base.tsx
@@ -78,8 +78,17 @@ export function SearchBar(props: SearcchBarProps) {
       </div>
       <div
         ref={ref}
-        className="relative flex w-full items-center gap-1 overflow-x-auto no_scrollbar"
+        className="relative flex w-full items-center gap-1 overflow-x-auto teppen-no-scrollbar"
       >
+        <style>{`
+          .teppen-no-scrollbar {
+            -ms-overflow-style: none;
+            scrollbar-width: none;
+          }
+          .teppen-no-scrollbar::-webkit-scrollbar {
+            display: none;
+          }
+        `}</style>
         <ConditionList conditions={props.conditions} />
         <div className="flex items-center min-w-64 w-full">
           <SearchBarInputForm size={props.size} />

--- a/src/search-bar/condition-search-bar/input-form.tsx
+++ b/src/search-bar/condition-search-bar/input-form.tsx
@@ -151,7 +151,7 @@ function InputSingleString(props: {
   return (
     <input
       id={generateId("ValueInput")}
-      className={`no_appearance w-full min-w-64 border-none px-2 py-1 focus:outline-none focus-visible:outline-none bg-transparent ${
+      className={`appearance-none w-full min-w-64 border-none px-2 py-1 focus:outline-none focus-visible:outline-none bg-transparent ${
         props.size === "small"
           ? "text-sm"
           : props.size === "large"
@@ -191,7 +191,7 @@ function InputSingleNumber(props: {
   return (
     <input
       id={generateId("ValueInput")}
-      className={`no_appearance w-full min-w-64 border-none px-2 py-1 focus:outline-none focus-visible:outline-none bg-transparent ${
+      className={`appearance-none w-full min-w-64 border-none px-2 py-1 focus:outline-none focus-visible:outline-none bg-transparent ${
         props.size === "small"
           ? "text-sm"
           : props.size === "large"

--- a/src/select-box/parts/input-area.tsx
+++ b/src/select-box/parts/input-area.tsx
@@ -80,7 +80,7 @@ export function InputArea(props: IPropsInputArea) {
       ref={props.inputRef}
       className={`px-2 py-1 ${
         props.no_appearance
-          ? "no_appearance border-none focus:outline-none focus-visible:outline-none bg-transparent w-full"
+          ? "appearance-none border-none focus:outline-none focus-visible:outline-none bg-transparent w-full"
           : "border border-gray-300 w-full"
       }`}
       type="text"

--- a/src/table/frame/frame.tsx
+++ b/src/table/frame/frame.tsx
@@ -73,11 +73,20 @@ export function Frame(props: IPropsFrame) {
       className="relative"
       style={{ maxHeight: props.maxHeight, maxWidth: props.maxWidth }}
     >
+      <style>{`
+          .teppen-no-scrollbar {
+            -ms-overflow-style: none;
+            scrollbar-width: none;
+          }
+          .teppen-no-scrollbar::-webkit-scrollbar {
+            display: none;
+          }
+        `}</style>
       <div
         ref={ref}
         id={props.id}
         className={`relative w-full h-full border border-gray-200 bg-white rounded-b-md overflow-auto ${
-          props.displayScroll ? "" : "no_scrollbar"
+          props.displayScroll ? "" : "teppen-no-scrollbar"
         }`}
         style={{ maxHeight: props.maxHeight, maxWidth: props.maxWidth }}
       >

--- a/src/table/header/header-v2.tsx
+++ b/src/table/header/header-v2.tsx
@@ -97,9 +97,18 @@ export function TableHeader<T extends DataRecord>(props: IPropsTableHeader<T>) {
         />
       </div>
 
+      <style>{`
+          .teppen-no-scrollbar {
+            -ms-overflow-style: none;
+            scrollbar-width: none;
+          }
+          .teppen-no-scrollbar::-webkit-scrollbar {
+            display: none;
+          }
+        `}</style>
       <div
         ref={ref}
-        className="relative max-w-full overflow-x-auto no_scrollbar"
+        className="relative max-w-full overflow-x-auto teppen-no-scrollbar"
       >
         <div className="flex h-[32px]">
           {props.checkbox && (


### PR DESCRIPTION
This pull request includes several changes to the CSS classes used for scrollbar and appearance styling, as well as updates to various components to reflect these changes. The most important changes include the removal of the `.no_scrollbar` and `.no_appearance` classes from the CSS file and their replacement with inline styles in the relevant components.

CSS class removals and replacements:

* [`src/main.css`](diffhunk://#diff-e161de5730429dfd420b12db03e6cf956bede92a68ada7ed8a33b268fcf3c95aL4-L18): Removed the `.no_scrollbar` and `.no_appearance` classes.

Component updates to use inline styles:

* [`src/search-bar/condition-search-bar/base.tsx`](diffhunk://#diff-4f5f476b84eaa2f5711c68081cd9c168f8c3f3560c201b68d0a88adddbe49a31L81-R91): Replaced the `no_scrollbar` class with `teppen-no-scrollbar` and added the corresponding inline styles.
* [`src/table/frame/frame.tsx`](diffhunk://#diff-0fc097287da75347e2f3ca84cc91cd36bb6864bcff73cc7b69ce8cab5ea759e2R76-R89): Replaced the `no_scrollbar` class with `teppen-no-scrollbar` and added the corresponding inline styles.
* [`src/table/header/header-v2.tsx`](diffhunk://#diff-0aee5b5cd07b0106feb83849365b34ec26a64e34a83c675e96333d468e0fb136R100-R111): Replaced the `no_scrollbar` class with `teppen-no-scrollbar` and added the corresponding inline styles.

Component updates to use standard appearance property:

* [`src/search-bar/condition-search-bar/input-form.tsx`](diffhunk://#diff-4c48aa7513c0468c6f336933a49538b6d669153fc8cd5ce8c1998f9c1bfdd2fcL154-R154): Replaced the `no_appearance` class with the `appearance-none` class for `InputSingleString` and `InputSingleNumber` components. [[1]](diffhunk://#diff-4c48aa7513c0468c6f336933a49538b6d669153fc8cd5ce8c1998f9c1bfdd2fcL154-R154) [[2]](diffhunk://#diff-4c48aa7513c0468c6f336933a49538b6d669153fc8cd5ce8c1998f9c1bfdd2fcL194-R194)
* [`src/select-box/parts/input-area.tsx`](diffhunk://#diff-a1d563e7ccdcfb3a481f9366856c18f3028428a28b12cf4863ae75bf1a76ed09L83-R83): Replaced the `no_appearance` class with the `appearance-none` class.…no-scrollbar and appearance-none for improved styling consistency