### PR TITLE
fix: improve null and empty string check in isMatchCondition function

### DIFF
--- a/src/table/filter-v2/hook.ts
+++ b/src/table/filter-v2/hook.ts
@@ -165,7 +165,8 @@ function isMatchCondition(
               );
             case "select:is_not_null":
               return (
-                (targetValue !== null && targetValue !== undefined) ||
+                targetValue !== null &&
+                targetValue !== undefined &&
                 targetValue !== ""
               );
           }


### PR DESCRIPTION
This pull request includes an important change to the `isMatchCondition` function in the `src/table/filter-v2/hook.ts` file. The change improves the logic for the "select:is_not_null" case by ensuring that the target value is not only not null or undefined but also not an empty string.

* [`src/table/filter-v2/hook.ts`](diffhunk://#diff-c47cab35b99a3ef217cb92cce8d9d8fe7ff7eb88f69aac1bb870356ebfa062d4L168-R169): Modified the "select:is_not_null" case in the `isMatchCondition` function to ensure the target value is not null, undefined, or an empty string.