### PR TITLE
fix: adjust position calculations in OptionsArea and improve test com…

### DIFF
--- a/src/select-box/options-window/component.tsx
+++ b/src/select-box/options-window/component.tsx
@@ -102,10 +102,7 @@ export function OptionsArea() {
             parentElement!.style.position.includes(style)
           );
 
-          if (hasPositionClass || hasPositionStyle) {
-            console.log(parentElement);
-            break;
-          }
+          if (hasPositionClass || hasPositionStyle) break;
 
           parentElement = parentElement.parentElement;
         }
@@ -120,8 +117,8 @@ export function OptionsArea() {
           if (parentElement) {
             const parentRect = parentElement.getBoundingClientRect();
             setPosition({
-              top: top - parentRect.top,
-              left: left - parentRect.left,
+              top: top - parentRect.top + parentElement.scrollTop,
+              left: left - parentRect.left + parentElement.scrollLeft,
             });
           } else {
             setPosition({

--- a/src/table/table/test-component.stories.tsx
+++ b/src/table/table/test-component.stories.tsx
@@ -16,10 +16,10 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {},
   render: () => (
-    <div className="p-8">
+    <div className="p-8 w-[200vw] h-[200vh]">
       <div className="relative flex w-full h-full border border-red-300 p-8">
         <div className="w-32 shrink-0 h-full"></div>
-        <div className="relative w-full h-full border border-blue-300 p-8">
+        <div className="absolute w-full h-[50vh] overflow-auto border border-blue-300 p-8">
           <TableTestComponent />
         </div>
       </div>


### PR DESCRIPTION
This pull request includes changes to the `OptionsArea` function in `src/select-box/options-window/component.tsx` and the `Default` story in `src/table/table/test-component.stories.tsx`. The changes aim to improve the positioning logic and enhance the test component's layout.

Improvements to positioning logic:

* [`src/select-box/options-window/component.tsx`](diffhunk://#diff-709d36154e2f595d12d3955b9af9d37c0a56c52a5e379a151183ae662f926bb6L105-R105): Simplified the conditional block by removing the `console.log` statement and directly breaking the loop when the condition is met.
* [`src/select-box/options-window/component.tsx`](diffhunk://#diff-709d36154e2f595d12d3955b9af9d37c0a56c52a5e379a151183ae662f926bb6L123-R121): Adjusted the calculation of the `top` and `left` positions to include the `scrollTop` and `scrollLeft` values of the parent element.

Enhancements to test component layout:

* [`src/table/table/test-component.stories.tsx`](diffhunk://#diff-dac78ae56067c14c9a73c4b012d4ac0348114d25206545bcbea9160f8d6a9decL19-R22): Modified the `Default` story to set the width and height of the outer `div` to `200vw` and `200vh`, respectively, and adjusted the inner `div` to be `absolute` with a height of `50vh` and `overflow-auto`.…ponent layout