### PR TITLE
fix: change checkbox wrapper from th to div in TableHeader component

### DIFF
--- a/src/table/header/header-v2.tsx
+++ b/src/table/header/header-v2.tsx
@@ -112,9 +112,9 @@ export function TableHeader<T extends DataRecord>(props: IPropsTableHeader<T>) {
       >
         <div className="flex h-[32px]">
           {props.checkbox && (
-            <th className="w-8 h-full">
+            <div className="w-8 h-full">
               <AllCheckbox rows={props.rows} />
-            </th>
+            </div>
           )}
           {props.cols.map((col) => {
             return (


### PR DESCRIPTION
This pull request includes a small change to the `TableHeader` component in `src/table/header/header-v2.tsx`. The change modifies the structure of the checkbox element from a `th` to a `div` to ensure proper rendering and styling.

* [`src/table/header/header-v2.tsx`](diffhunk://#diff-0aee5b5cd07b0106feb83849365b34ec26a64e34a83c675e96333d468e0fb136L115-R117): Changed the checkbox container from a `th` to a `div` to improve layout consistency.