### PR TITLE
chore: add permissions for contents and pages in release workflow

### DIFF
--- a/.github/workflows/publish_catalog.yml
+++ b/.github/workflows/publish_catalog.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pages: write
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to adjust permissions for the `release` job in the `publish_catalog.yml` file.

* [`.github/workflows/publish_catalog.yml`](diffhunk://#diff-da486ce540749844f226c290d775acb93578a75a29132049d143e34cd0074b2aR14-R16): Added `contents: write` and `pages: write` permissions to the `release` job to enable necessary actions during the release process.