### PR TITLE
feat: add environment configuration for GitHub Pages deployment

### DIFF
--- a/.github/workflows/publish_catalog.yml
+++ b/.github/workflows/publish_catalog.yml
@@ -14,6 +14,9 @@ jobs:
     permissions:
       contents: write
       pages: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     if: |
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release'))


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for publishing the catalog by adding an environment configuration to the `jobs:` section. The environment is set to `github-pages` with a dynamic URL.

Workflow enhancements:

* [`.github/workflows/publish_catalog.yml`](diffhunk://#diff-da486ce540749844f226c290d775acb93578a75a29132049d143e34cd0074b2aR17-R19): Added `environment` configuration with `name` set to `github-pages` and `url` dynamically assigned from the `steps.deployment.outputs.page_url`. This change ensures that the deployment environment is explicitly defined and associated with GitHub Pages.