### PR TITLE
chore: update permissions in GitHub Actions workflow for release

### DIFF
--- a/.github/workflows/publish_catalog.yml
+++ b/.github/workflows/publish_catalog.yml
@@ -12,8 +12,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pages: write
+      id-token: write
+      contents: read
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/publish_catalog.yml` to adjust permissions for better security and functionality.

Changes to workflow permissions:

* [`jobs.release.permissions`](diffhunk://#diff-da486ce540749844f226c290d775acb93578a75a29132049d143e34cd0074b2aL15-R16): Replaced `contents: write` and `pages: write` with `id-token: write` and `contents: read` to refine access levels and enhance security.