### PR TITLE
chore: move permissions to the top level in GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish_catalog.yml
+++ b/.github/workflows/publish_catalog.yml
@@ -8,12 +8,14 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+  pages: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow for publishing the catalog. The change adjusts permissions and reorganizes the `jobs` section for better clarity and functionality.

Workflow updates:

* [`.github/workflows/publish_catalog.yml`](diffhunk://#diff-da486ce540749844f226c290d775acb93578a75a29132049d143e34cd0074b2aL11-R18): Added the `pages: write` permission and reordered the `jobs` section to ensure proper configuration for the `release` job.